### PR TITLE
Added /day support for Windows task resource.

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,10 +510,11 @@ Server 2008 due to API usage.
 - user: The user to run the task as. (requires password)
 - password: The user's password. (requires user)
 - run_level: Run with limited or highest privileges.
-- frequency: Frequency with which to run the task. (hourly, daily, ect.)
+- frequency: Frequency with which to run the task. (hourly, daily, etc.)
 - frequency_modifier: Multiple for frequency. (15 minutes, 2 days)
 - start_day: Specifies the first date on which the task runs. Optional string (MM/DD/YYYY)
 - start_time: Specifies the start time to run the task. Optional string (HH:mm)
+- day: For monthly or weekly tasks, the day(s) on which the task runs.  (MON - SUN, *, 1 - 31)
 
 #### Examples
 

--- a/resources/task.rb
+++ b/resources/task.rb
@@ -41,6 +41,7 @@ attribute :frequency, :equal_to => [:minute,
                                     :on_idle], :default => :hourly
 attribute :start_day, :kind_of => String, :default => nil
 attribute :start_time, :kind_of => String, :default => nil
+attribute :day, :kind_of => [ String, Integer ], :default => nil
 
 attr_accessor :exists, :status, :enabled
 


### PR DESCRIPTION
Needed to create a monthly task that occurred on the 20th of every month.  Didn't see support for doing that, so added this.