### PR TITLE
Move reboot_pending? method to windows_helper

### DIFF
--- a/libraries/windows_helper.rb
+++ b/libraries/windows_helper.rb
@@ -105,6 +105,8 @@ module Windows
       # "9306cdfc-c4a1-4a22-9996-848cb67eddc3"=1
       (::Registry.key_exists?('HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\RebootRequired') &&
         ::Registry.get_values('HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\RebootRequired').select { |v| v[2] == 1 }.any?) ||
+      # this key will only exit if the system is pending a reboot
+      ::Registry.key_exists?('HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootPending') ||
       # 1 or 2 for 'Flags' value means reboot pending
       (::Registry.key_exists?('HKLM\SOFTWARE\Microsoft\Updates\UpdateExeVolatile') &&
         [1, 2].include?(::Registry::get_value('HKLM\SOFTWARE\Microsoft\Updates\UpdateExeVolatile', 'Flags')))

--- a/libraries/windows_helper.rb
+++ b/libraries/windows_helper.rb
@@ -96,6 +96,19 @@ module Windows
       buf.strip
     end
 
+    # traditional ways to determine if windows has pending reboot
+    def self.reboot_pending?
+      # Any files listed here means reboot needed
+      (::Registry.key_exists?('HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\PendingFileRenameOperations') &&
+        ::Registry.get_value('HKLM\SYSTEM\CurrentControlSet\Control\Session Manager', 'PendingFileRenameOperations').any?) ||
+      # 1 for any value means reboot pending
+      # "9306cdfc-c4a1-4a22-9996-848cb67eddc3"=1
+      (::Registry.key_exists?('HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\RebootRequired') &&
+        ::Registry.get_values('HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\RebootRequired').select { |v| v[2] == 1 }.any?) ||
+      # 1 or 2 for 'Flags' value means reboot pending
+      (::Registry.key_exists?('HKLM\SOFTWARE\Microsoft\Updates\UpdateExeVolatile') &&
+        [1, 2].include?(::Registry::get_value('HKLM\SOFTWARE\Microsoft\Updates\UpdateExeVolatile', 'Flags')))
+    end
   end
 end
 


### PR DESCRIPTION
Move method `reboot_pending?` from `windows_reboot_handler` to `windows_helper`.
This allows thirdparty providers to use the detection code.
I also added another check to the `reboot_pending?` method to handle CBS required reboot.