### PR TITLE
Fix documentation for windows_task

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,7 +488,7 @@ Server 2008 due to API usage.
 - name: name attribute, The task name.
 - command: The command the task will run.
 - cwd: The directory the task will be run from.
-- user: The user to run the task as. (requires password)
+- user: The user to run the task as.
 - password: The user's password. (requires user)
 - run_level: Run with limited or highest privileges.
 - frequency: Frequency with which to run the task. (hourly, daily, ect.)
@@ -504,7 +504,7 @@ windows_task 'Chef client' do
   user 'Administrator'
   password '$ecR3t'
   cwd 'C:\chef\bin'
-  command 'chef-client -L C:\tmp\'
+  command 'chef-client -L C:\tmp\\'
   run_level :highest
   frequency :minute
   frequency_modifier 15
@@ -517,7 +517,7 @@ windows_task 'Chef client' do
   user 'Administrator'
   password 'N3wPassW0Rd'
   cwd 'C:\chef\bin'
-  command 'chef-client -L C:\chef\logs\'
+  command 'chef-client -L C:\chef\logs\\'
   action :change
 end
 ```


### PR DESCRIPTION
Currently the documentation states that when a user is given, it also needs a password.

    user: The user to run the task as. (requires password)

This is incorrect. The [code](https://github.com/opscode-cookbooks/windows/blob/master/providers/task.rb#L28) only requires that a user is supplied if a password is supplied. If a user is supplied, a password is not required.

    if @new_resource.user and @new_resource.password.nil? then Chef::Log.debug "#{@new_resource} did not specify a password, creating task without a password" end

This is useful when setting the user as the system account since the system account has no password.

    windows_task "Run Foobar Daily" do
        command 'foobar.exe'
        frequency :daily
        cwd 'c:\windows\system32'
        user 'NT AUTHORITY\SYSTEM'
    end