### PR TITLE
Define a default provider for windows_feature

### DIFF
--- a/resources/feature.rb
+++ b/resources/feature.rb
@@ -40,5 +40,7 @@ def locate_default_provider
     :windows_feature_dism
   elsif ::File.exists?(locate_sysnative_cmd('servermanagercmd.exe'))
     :windows_feature_servermanagercmd
+  else
+    :windows_feature_powershell
   end
 end


### PR DESCRIPTION
The install_windows_feature ChefSpec matcher raises an error due to not having a default provider for windows_feature. See #157 for more details on this issue.

This pull request sets a default provider for windows_feature.