### PR TITLE
Adding basic rspec tests for win2k12r2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 Berksfile.lock
 Gemfile.lock
 .bundle
+.rvmrc
+.idea

--- a/Berksfile
+++ b/Berksfile
@@ -1,4 +1,4 @@
-source "https://supermarket.getchef.com"
+source "https://supermarket.chef.io"
 
 metadata
 

--- a/Gemfile
+++ b/Gemfile
@@ -11,4 +11,5 @@ group :development do
 
   gem "berkshelf"
   gem "vagrant-wrapper", ">= 2.0"
+  gem "chefspec"
 end

--- a/chefignore
+++ b/chefignore
@@ -1,2 +1,4 @@
 .git
 .kitchen
+.rvmrc
+

--- a/rvmrc
+++ b/rvmrc
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# This is an RVM Project .rvmrc file, used to automatically load the ruby
+# development environment upon cd'ing into the directory
+
+# First we specify our desired <ruby>[@<gemset>], the @gemset name is optional.
+environment_id="ruby-2.1.2@windows"
+
+# First we attempt to load the desired environment directly from the environment
+# file. This is very fast and efficient compared to running through the entire
+# CLI and selector. If you want feedback on which environment was used then
+# insert the word 'use' after --create as this triggers verbose mode.
+#
+if [[ -d "${rvm_path:-$HOME/.rvm}/environments" \
+  && -s "${rvm_path:-$HOME/.rvm}/environments/$environment_id" ]]
+then
+  \. "${rvm_path:-$HOME/.rvm}/environments/$environment_id"
+
+  if [[ -s "${rvm_path:-$HOME/.rvm}/hooks/after_use" ]]
+  then
+    . "${rvm_path:-$HOME/.rvm}/hooks/after_use"
+  fi
+else
+  # If the environment file has not yet been created, use the RVM CLI to select.
+  if ! rvm --create  "$environment_id"
+  then
+    echo "Failed to create RVM environment '${environment_id}'."
+    return 1
+  fi
+fi
+
+if [[ $- == *i* ]] # check for interactive shells
+then
+    echo "Using: $(tput setaf 2)$GEM_HOME$(tput sgr0)" # show the user the ruby and gemset they are using in green
+else 
+	echo "Using: $GEM_HOME" # don't use colors in interactive shells
+fi
+

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe 'windows::default' do
+  let(:chef_run) do
+    runner = ChefSpec::Runner.new(platform: 'windows', version: '2012R2')
+    runner.converge(described_recipe)
+  end
+
+  gems=%w(win32-api win32-service windows-api windows-pr win32-dir win32-event win32-mutex)
+  gems.each() do |gem|
+  it 'should include the community windows recipe' do
+    expect(chef_run).to install_chef_gem(gem)
+  end
+    end
+
+end
+

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -1,17 +1,35 @@
 require 'spec_helper'
 
 describe 'windows::default' do
-  let(:chef_run) do
-    runner = ChefSpec::Runner.new(platform: 'windows', version: '2012R2')
-    runner.converge(described_recipe)
+  context '2012R2' do
+    version = '2012R2'
+    let(:chef_run) do
+      runner = ChefSpec::Runner.new(platform: 'windows', version: version)
+      runner.converge(described_recipe)
+    end
+
+    gems=%w(win32-api win32-service windows-api windows-pr win32-dir win32-event win32-mutex)
+    gems.each() do |gem|
+      it "should install gems #{gems}" do
+        expect(chef_run).to install_chef_gem(gem)
+      end
+    end
   end
 
-  gems=%w(win32-api win32-service windows-api windows-pr win32-dir win32-event win32-mutex)
-  gems.each() do |gem|
-  it 'should include the community windows recipe' do
-    expect(chef_run).to install_chef_gem(gem)
-  end
+  context '2008R2' do
+    version = '2008R2'
+    let(:chef_run) do
+      runner = ChefSpec::Runner.new(platform: 'windows', version: version)
+      runner.converge(described_recipe)
     end
+
+    gems=%w(win32-api win32-service windows-api windows-pr win32-dir win32-event win32-mutex)
+    gems.each() do |gem|
+      it "should install gems #{gems}" do
+        expect(chef_run).to install_chef_gem(gem)
+      end
+    end
+  end
 
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,14 @@
+require 'chefspec'
+require 'chefspec/berkshelf'
+require 'chefspec/cacher'
+
+RSpec.configure do |config|
+  config.log_level = :fatal
+  config.filter_run focus: true
+  config.run_all_when_everything_filtered = true
+  config.order = 'random'
+  config.platform = 'windows'
+  config.version = '2012R2'
+end
+
+at_exit { ChefSpec::Coverage.report! }


### PR DESCRIPTION
I find that developing cookbooks with server spec only is way to slow. Each time you run kitchen test it can take several minutes if not more, especially if there are multiple platforms.  I think getting some basic rspec tests that only take a few seconds really helps to speed things up.  Since 8.1 windows is kind of old I went with versions 2008r2 and 2012R2.   