### PR TITLE
Only define ExpandEnvironmentStrings when not already defined

### DIFF
--- a/libraries/windows_helper.rb
+++ b/libraries/windows_helper.rb
@@ -26,7 +26,7 @@ module Windows
 
     AUTO_RUN_KEY = 'HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Run'.freeze unless defined?(AUTO_RUN_KEY)
     ENV_KEY = 'HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Environment'.freeze unless defined?(ENV_KEY)
-    ExpandEnvironmentStrings = Win32API.new('kernel32', 'ExpandEnvironmentStrings', ['P', 'P', 'L'], 'L') if Chef::Platform.windows?
+    ExpandEnvironmentStrings = Win32API.new('kernel32', 'ExpandEnvironmentStrings', ['P', 'P', 'L'], 'L') if Chef::Platform.windows? and !defined?(ExpandEnvironmentStrings)
 
     # returns windows friendly version of the provided path,
     # ensures backslashes are used everywhere


### PR DESCRIPTION
Similar to what was done in https://github.com/opscode-cookbooks/windows/pull/25, only define `ExpandEnvironmentStrings` when it is not defined already.

I wasn't sure about freezing it since it's not a scalar constant, hence I chose to not freeze it.

This solves already defined constant warning when cookbook is included multiple times:

```
cookbooks/windows/libraries/windows_helper.rb:29: warning: already initialized constant Windows::Helper::ExpandEnvironmentStrings 
cookbooks/windows/libraries/windows_helper.rb:29: warning: previous definition of ExpandEnvironmentStrings was here
```

Regards,
Matt