### PR TITLE
powershell_out uses powershell 64bit on x64 node

### DIFF
--- a/libraries/powershell_out.rb
+++ b/libraries/powershell_out.rb
@@ -2,6 +2,7 @@ class Chef
   module Mixin
     module PowershellOut
       include Chef::Mixin::ShellOut
+      include Powershell::Helper
 
       begin
         include Chef::Mixin::WindowsArchitectureHelper
@@ -71,7 +72,7 @@ class Chef
           "-InputFormat None"
         ]
 
-        command = "powershell.exe #{flags.join(' ')} -Command \"#{script}\""
+        command = "#{interpreter} #{flags.join(' ')} -Command \"#{script}\""
         command
       end
     end


### PR DESCRIPTION
This PR resolve #169 
It includes `Powershell::Helper` inside `Chef::Mixin::PowershellOut` and leverage the [`interpreter` function](https://github.com/opscode-cookbooks/windows/blob/master/libraries/powershell_helper.rb#L31)