### PR TITLE
Switch test-kitchen to official development branch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,7 @@ source "https://rubygems.org"
 
 group :development do
   # The current official branch is the 'windows-guest-support' branch, but it isn't working for me right now.
-  # gem "test-kitchen", :git => 'https://github.com/test-kitchen/test-kitchen.git', :branch => 'windows-guest-support'
-  gem 'test-kitchen', git: 'https://github.com/jdmundrawala/test-kitchen.git', :branch => 'Transport'
+  gem "test-kitchen", :git => 'https://github.com/test-kitchen/test-kitchen.git', :branch => 'windows-guest-support'
 
   # afiune/Transport supports copying files from Windows -> Windows
   # gem 'kitchen-vagrant', git: 'https://github.com/jdmundrawala/kitchen-vagrant.git', :branch => 'Transport'


### PR DESCRIPTION
`bundle exec kitchen test` worked on Windows 8.1 host. /cc @mattstratton 