### PR TITLE
Add base serverspec test

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -31,7 +31,7 @@ platforms:
       box: windows-8.1
       box_url: https://s3-us-west-2.amazonaws.com/chef-box-cutter/windows/virtualbox4.3.20/eval-win81x64-enterprise-nocm-1.0.3.box
     provisioner:
-      require_chef_omnibus: 12.0.0
+      require_chef_omnibus: 12
 
 suites:
   - name: default

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -17,19 +17,19 @@ platforms:
   - name: windows-8.1-chef11.10.4
     driver_config:
       box: windows-8.1
-      box_url: https://s3-us-west-2.amazonaws.com/chef-box-cutter/windows/virtualbox4.3.20/eval-win81x64-enterprise-nocm-1.0.3.box
+      box_url: http://cdn.box-cutter.com/windows/virtualbox4.3.20/eval-win81x64-enterprise-nocm-1.0.2.box
     provisioner:
       require_chef_omnibus: 11.10.4
   - name: windows-8.1-chef11.16.4
     driver_config:
       box: windows-8.1
-      box_url: https://s3-us-west-2.amazonaws.com/chef-box-cutter/windows/virtualbox4.3.20/eval-win81x64-enterprise-nocm-1.0.3.box
+      box_url: http://cdn.box-cutter.com/windows/virtualbox4.3.20/eval-win81x64-enterprise-nocm-1.0.2.box
     provisioner:
       require_chef_omnibus: 11.16.4
   - name: windows-8.1-chef12
     driver_config:
       box: windows-8.1
-      box_url: https://s3-us-west-2.amazonaws.com/chef-box-cutter/windows/virtualbox4.3.20/eval-win81x64-enterprise-nocm-1.0.3.box
+      box_url: http://cdn.box-cutter.com/windows/virtualbox4.3.20/eval-win81x64-enterprise-nocm-1.0.2.box
     provisioner:
       require_chef_omnibus: 12
 

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -17,19 +17,19 @@ platforms:
   - name: windows-8.1-chef11.10.4
     driver_config:
       box: windows-8.1
-      box_url: http://cdn.box-cutter.com/windows/virtualbox4.3.20/eval-win81x64-enterprise-nocm-1.0.2.box
+      box_url: https://s3-us-west-2.amazonaws.com/chef-box-cutter/windows/virtualbox4.3.20/eval-win81x64-enterprise-nocm-1.0.3.box
     provisioner:
       require_chef_omnibus: 11.10.4
-  - name: windows-8.1-chef11
+  - name: windows-8.1-chef11.16.4
     driver_config:
       box: windows-8.1
-      box_url: http://cdn.box-cutter.com/windows/virtualbox4.3.20/eval-win81x64-enterprise-nocm-1.0.2.box
+      box_url: https://s3-us-west-2.amazonaws.com/chef-box-cutter/windows/virtualbox4.3.20/eval-win81x64-enterprise-nocm-1.0.3.box
     provisioner:
       require_chef_omnibus: 11.16.4
   - name: windows-8.1-chef12
     driver_config:
       box: windows-8.1
-      box_url: http://cdn.box-cutter.com/windows/virtualbox4.3.20/eval-win81x64-enterprise-nocm-1.0.2.box
+      box_url: https://s3-us-west-2.amazonaws.com/chef-box-cutter/windows/virtualbox4.3.20/eval-win81x64-enterprise-nocm-1.0.3.box
     provisioner:
       require_chef_omnibus: 12.0.0
 

--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,8 @@ source "https://rubygems.org"
 
 group :development do
   # The current official branch is the 'windows-guest-support' branch, but it isn't working for me right now.
-  # gem "test-kitchen", :git => 'https://github.com/test-kitchen/test-kitchen.git', :branch => 'windows-guest-support'
-  gem 'test-kitchen', git: 'https://github.com/jdmundrawala/test-kitchen.git', :branch => 'Transport'
+  gem "test-kitchen", :git => 'https://github.com/test-kitchen/test-kitchen.git', :branch => 'windows-guest-support'
+  #gem 'test-kitchen', git: 'https://github.com/test-kitchen/test-kitchen.git', :branch => 'windows-guest-support'
 
   # afiune/Transport supports copying files from Windows -> Windows
   # gem 'kitchen-vagrant', git: 'https://github.com/jdmundrawala/kitchen-vagrant.git', :branch => 'Transport'

--- a/Gemfile
+++ b/Gemfile
@@ -6,8 +6,8 @@ group :development do
   #gem 'test-kitchen', git: 'https://github.com/test-kitchen/test-kitchen.git', :branch => 'windows-guest-support'
 
   # afiune/Transport supports copying files from Windows -> Windows
-  # gem 'kitchen-vagrant', git: 'https://github.com/jdmundrawala/kitchen-vagrant.git', :branch => 'Transport'
-  gem 'kitchen-vagrant', git: 'https://github.com/afiune/kitchen-vagrant.git', :branch => 'Transport'
+  gem 'kitchen-vagrant', git: 'https://github.com/jdmundrawala/kitchen-vagrant.git', :branch => 'Transport'
+  #gem 'kitchen-vagrant', git: 'https://github.com/afiune/kitchen-vagrant.git', :branch => 'Transport'
 
   gem "berkshelf"
   gem "vagrant-wrapper", ">= 2.0"

--- a/Gemfile
+++ b/Gemfile
@@ -1,13 +1,8 @@
 source "https://rubygems.org"
 
 group :development do
-  # The current official branch is the 'windows-guest-support' branch, but it isn't working for me right now.
   gem "test-kitchen", :git => 'https://github.com/test-kitchen/test-kitchen.git', :branch => 'windows-guest-support'
-
-  # afiune/Transport supports copying files from Windows -> Windows
   gem 'kitchen-vagrant', git: 'https://github.com/jdmundrawala/kitchen-vagrant.git', :branch => 'Transport'
-  #gem 'kitchen-vagrant', git: 'https://github.com/afiune/kitchen-vagrant.git', :branch => 'Transport'
-
   gem "berkshelf"
   gem "vagrant-wrapper", ">= 2.0"
 end

--- a/test/integration/default/serverspec/hosts_spec.rb
+++ b/test/integration/default/serverspec/hosts_spec.rb
@@ -2,8 +2,8 @@ require 'spec_helper'
 
 describe 'Host File' do
 
-  describe file('c:/windows/system32/drivers/etc/hosts') do
-  it { should be_file }
+describe file('c:/opscode') do
+  it { should be_directory }
 end
 
 end


### PR DESCRIPTION
Added a base serverspec test to force a busser test to allow for Kitchen verify. Also changed the Chef client version from 12.0.0 to "12" so it just pulls the latest version of chef-client 12.