### PR TITLE
Added 'end' action to windows_task to kill a running task.

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,6 +499,7 @@ Server 2008 due to API usage.
 - :create: creates a task
 - :delete: deletes a task
 - :run: runs a task
+- :end: ends a task
 - :change: changes the un/pw or command of a task
 - :enable: enable a task
 - :disable: disable a task

--- a/providers/task.rb
+++ b/providers/task.rb
@@ -87,6 +87,22 @@ action :delete do
   end
 end
 
+action :end do
+  if @current_resource.exists
+    if @current_resource.status != :running
+      Chef::Log.debug "#{@new_resource} is not running - nothing to do"
+    else
+      cmd =  "schtasks /End /TN \"#{@current_resource.name}\" "
+      shell_out!(cmd, {:returns => [0]})
+      @new_resource.updated_by_last_action true
+      Chef::Log.info "#{@new_resource} task ended"
+    end
+  else
+    Chef::Log.fatal "#{@new_resource} task doesn't exist - nothing to do"
+    raise Errno::ENOENT, "#{@new_resource}: task does not exist, cannot end"
+  end
+end
+
 action :enable do
   if @current_resource.exists
     if @current_resource.enabled

--- a/resources/task.rb
+++ b/resources/task.rb
@@ -20,7 +20,7 @@
 
 # Passwords can't be loaded for existing tasks, making :modify both confusing
 # and not very useful
-actions :create, :delete, :run, :change, :enable, :disable
+actions :create, :delete, :run, :end, :change, :enable, :disable
 
 attribute :name, :kind_of => String, :name_attribute => true, :regex => [ /\A[^\\\/\:\*\?\<\>\|]+\z/ ]
 attribute :command, :kind_of => String


### PR DESCRIPTION
The windows_task feature can be used as a way of running prolonged background tasks. It is sometimes necessary to restart such tasks due to configuration changes. 