### PR TITLE
Update Serverspec spec_helper to detect-and-set Windows platforms.

### DIFF
--- a/test/integration/default/serverspec/spec_helper.rb
+++ b/test/integration/default/serverspec/spec_helper.rb
@@ -1,3 +1,9 @@
 require 'serverspec'
 
 set :backend, :cmd
+
+require 'rbconfig'
+case RbConfig::CONFIG['host_os']
+when /mswin|msys|mingw|cygwin|bccwin|wince|emc/
+  set :os, :family => 'windows'
+end


### PR DESCRIPTION
There may be a regression in serverspec/specinfra#351 which seems to now
require setting:

    set :os, :family => 'windows'

when operating on Windows-based nodes.

This may not be the prettiest and permanent of fixes, but an experiment
for future projects which may need to conditionally set this value.