### PR TITLE
Update testing stack with the latest test-kitchen changes.

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -6,6 +6,9 @@ driver:
     cpus: 2
     memory: 4096
 
+driver_config:
+  communicator: winrm
+
 transport:
   name: winrm
 

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,6 +1,5 @@
 ---
 driver:
-  forward_agent: yes
   name: vagrant
   customize:
     cpus: 2

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,8 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
 group :development do
-  gem "test-kitchen", :git => 'https://github.com/test-kitchen/test-kitchen.git', :branch => 'windows-guest-support'
-  gem 'kitchen-vagrant', git: 'https://github.com/test-kitchen/kitchen-vagrant.git', :branch => 'windows-guest-support'
-  gem "berkshelf"
-  gem "vagrant-wrapper", ">= 2.0"
+  gem 'test-kitchen',     '1.4.0.beta.2'
+  gem 'kitchen-vagrant',  '0.17.0.beta.3'
+  gem 'berkshelf'
+  gem 'vagrant-wrapper',  '>= 2.0'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,8 @@
 source 'https://rubygems.org'
 
 group :development do
-  gem 'test-kitchen',     '1.4.0.beta.2'
-  gem 'kitchen-vagrant',  '0.17.0.beta.3'
+  gem 'test-kitchen',     '>= 1.4.0.beta.2'
+  gem 'kitchen-vagrant',  '>= 0.17.0.beta.4'
   gem 'berkshelf'
   gem 'vagrant-wrapper',  '>= 2.0'
 end


### PR DESCRIPTION
A new parameter was added to the driver config so that the correct
communicator is setup. Technically transport is not needed anymore
since it is discovered with the name, but I left it in there to be
explicit.

I bumped the gems to the latest working betas. Kitchen-vagrant
0.17.0.beta3 requires the vagrant-winrm plugin and will display
a message stating that you need to install it if you have not
already. I think this should suffice as a warning, but I could add
a special testing section to the README if necessary.

This has been tested with all 3 suites.