### PR TITLE
enable windows_task to accept pathed task names + update test-kitchen

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,9 @@
 source "https://rubygems.org"
 
 group :development do
-  gem "test-kitchen", :git => 'https://github.com/test-kitchen/test-kitchen.git', :branch => 'windows-guest-support'
-  gem 'kitchen-vagrant', git: 'https://github.com/test-kitchen/kitchen-vagrant.git', :branch => 'windows-guest-support'
+  gem "test-kitchen"
+  gem 'kitchen-vagrant'
+  gem 'winrm-transport'
   gem "berkshelf"
   gem "vagrant-wrapper", ">= 2.0"
 end

--- a/README.md
+++ b/README.md
@@ -532,7 +532,7 @@ Server 2008 due to API usage.
 - :disable: disable a task
 
 #### Attribute Parameters
-- name: name attribute, The task name.
+- name: name attribute, The task name. ("Task Name" or "/Task Name")
 - command: The command the task will run.
 - cwd: The directory the task will be run from.
 - user: The user to run the task as. (requires password)

--- a/providers/task.rb
+++ b/providers/task.rb
@@ -125,8 +125,9 @@ def load_current_resource
   @current_resource = Chef::Resource::WindowsTask.new(@new_resource.name)
   @current_resource.name(@new_resource.name)
 
+  pathed_task_name = @new_resource.name[0,1] == '\\' ? @new_resource.name : @new_resource.name.prepend('\\')
   task_hash = load_task_hash(@current_resource.name)
-  if task_hash[:TaskName] == '\\' + @new_resource.name
+  if task_hash[:TaskName] == pathed_task_name
     @current_resource.exists = true
     if task_hash[:Status] == "Running"
       @current_resource.status = :running

--- a/resources/task.rb
+++ b/resources/task.rb
@@ -22,7 +22,7 @@
 # and not very useful
 actions :create, :delete, :run, :change, :enable, :disable
 
-attribute :name, :kind_of => String, :name_attribute => true, :regex => [ /\A[^\\\/\:\*\?\<\>\|]+\z/ ]
+attribute :name, :kind_of => String, :name_attribute => true, :regex => [ /\A[^\/\:\*\?\<\>\|]+\z/ ]
 attribute :command, :kind_of => String
 attribute :cwd, :kind_of => String
 attribute :user, :kind_of => String, :default => nil

--- a/test/cookbooks/minimal/recipes/default.rb
+++ b/test/cookbooks/minimal/recipes/default.rb
@@ -29,3 +29,28 @@ windows_task 'disable chef test' do
   name 'chef test'
   action :disable
 end
+
+windows_task 'create chef test' do
+  name 'chef\\chef test'
+  action :create
+  cwd "C:\\"
+  command 'dir'
+end
+
+windows_task 'disable chef test' do
+  name 'chef\\chef test'
+  action :disable
+end
+
+windows_task 'create chef test' do
+  name '\\chef\\chef test2'
+  action :create
+  cwd "C:\\"
+  command 'dir'
+end
+
+windows_task 'disable chef test' do
+  name '\\chef\\chef test2'
+  action :disable
+end
+


### PR DESCRIPTION
This allows windows_task to accept the following task name formats:
```ruby
"Task Name"
"/Task Name"
"Path/Task Name"
"/Path/Task Name"
```

It also updates the test-kitchen references to work with 1.4.0 so that the tests can run