### PR TITLE
support installing certificates and binding to ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,15 +95,15 @@ end
 Installs a certificate into the Windows certificate store from a file, and grants read-only access to the private key for designated accounts.
 
 #### Actions
-- :create: creates or updates a certificate
-- :delete: deletes a certificate
-- :acl_add: adds read-only entries to a certificte's private key ACL
+- :create: creates or updates a certificate.
+- :delete: deletes a certificate.
+- :acl_add: adds read-only entries to a certificate's private key ACL.
 
 #### Attribute Parameters
 - source: name attribute. The source file (for create and acl_add), thumprint (for delete and acl_add) or subject (for delete).
 - pfx_password: the password to access the source if it is a pfx file.
-- private_key_acl: array of 'domain\account' entries to be granted read-only access to the certificte's private key. This is not idempotent.
-- store_name: the certificate store to maniplate. One of MY (default : personal store), CA (trusted intermediate store) or ROOT (trusted root store)
+- private_key_acl: array of 'domain\account' entries to be granted read-only access to the certificate's private key. This is not idempotent.
+- store_name: the certificate store to maniplate. One of MY (default : personal store), CA (trusted intermediate store) or ROOT (trusted root store).
 - user_store: if false (default) then use the local machine store; if true then use the current user's store.
 
 #### Examples
@@ -134,16 +134,16 @@ end
 Binds a certificate to an HTTP port in order to enable TLS communication.
 
 #### Actions
-- :create: creates or updates a binding
-- :delete: deletes a binding
+- :create: creates or updates a binding.
+- :delete: deletes a binding.
 
 #### Attribute Parameters
 - cert_name: name attribute. The thumprint(hash) or subject that identifies the certicate to be bound.
-- name_kind: indicates the type of cert_name. One of :subject (default) or :hash
-- address: the address to bind against. Default is 0.0.0.0 (all IP addresses)
+- name_kind: indicates the type of cert_name. One of :subject (default) or :hash.
+- address: the address to bind against. Default is 0.0.0.0 (all IP addresses).
 - port: the port to bind against. Default is 443.
 - app_id: the GUID that defines the application that owns the binding. Default is the values used by IIS.
-- store_name: the store to locate the certificate in. One of MY (default : personal store), CA (trusted intermediate store) or ROOT (trusted root store)
+- store_name: the store to locate the certificate in. One of MY (default : personal store), CA (trusted intermediate store) or ROOT (trusted root store).
 
 #### Examples
 ```ruby

--- a/README.md
+++ b/README.md
@@ -90,6 +90,78 @@ windows_batch 'echo some env vars' do
 end
 ```
 
+### windows_certificate
+
+Installs a certificate into the Windows certificate store from a file, and grants read-only access to the private key for designated accounts
+
+#### Actions
+- :create: creates or updates a certificate
+- :delete: deletes a certificate
+- :acl_add: adds read-only entries to a certificte's private key ACL
+
+#### Attribute Parameters
+- source: name attribute. The source file (for create and acl_add) or thumprint/subject (for delete and acl_add).
+- pfx_password: the password to access the source if it is a pfx file.
+- private_key_acl: array of 'domain\account' entries to be granted read-only access to the certificte's private key. This is not idempotent.
+- store_name: the certificate store to maniplate. One of MY (default : personal store), CA (trusted intermediate store) or ROOT (trusted root store)
+- user_store: if false (default) then use the local machine store; if true then use the current user's store.
+
+#### Examples
+```ruby
+# Add PFX cert to local machine personal store and grant accounts read-only access to private key
+windows_certificate "c:/test/mycert.pfx" do
+	pfx_password	"password"
+	private_key_acl	["acme\fred", "pc\jane"]
+end
+```
+
+```ruby
+# Add cert to trusted intermediate store
+windows_certificate "c:/test/mycert.cer" do
+	store_name	"CA"
+end
+```
+
+```ruby
+# Remove all certicates matching the subject
+windows_certificate "me.acme.com" do
+	action :delete
+end
+```
+
+### windows_certificate_binding
+
+Binds a certificate to an HTTP port in order to enable TLS communication.
+
+#### Actions
+- :create: creates or updates a binding
+- :delete: deletes a binding
+
+#### Attribute Parameters
+- cert_name: name attribute. The thumprint(hash) or subject that identifies the certicate to be bound.
+- name_kind: indicates the type of cert_name. One of :subject (default) or :hash
+- address: the address to bind against. Default is 0.0.0.0 (all IP addresses)
+- port: the port to bind against. Default is 443.
+- app_id: the GUID that defines the application that owns the binding. Default is the values used by IIS.
+- store_name: the store to locate the certificate in. One of MY (default : personal store), CA (trusted intermediate store) or ROOT (trusted root store)
+
+#### Examples
+```ruby
+# Bind the first certificate matching the subject to the default TLS port
+windows_certificate_binding "me.acme.com" do
+end
+```
+
+```ruby
+# Bind a cert from the CA store with the given hash to port 4334
+windows_certificate_binding "me.acme.com" do
+	cert_name	"d234567890a23f567c901e345bc8901d34567890"
+	name_kind	:hash
+	store_name	"CA"
+	port		4334
+end
+```
+
 ### windows_feature
 Windows Roles and Features can be thought of as built-in operating system packages that ship with the OS.  A server role is a set of software programs that, when they are installed and properly configured, lets a computer perform a specific function for multiple users or other computers within a network.  A Role can have multiple Role Services that provide functionality to the Role.  Role services are software programs that provide the functionality of a role. Features are software programs that, although they are not directly parts of roles, can support or augment the functionality of one or more roles, or improve the functionality of the server, regardless of which roles are installed.  Collectively we refer to all of these attributes as 'features'.
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ end
 
 ### windows_certificate
 
-Installs a certificate into the Windows certificate store from a file, and grants read-only access to the private key for designated accounts
+Installs a certificate into the Windows certificate store from a file, and grants read-only access to the private key for designated accounts.
+Note that this resource generates powershell_script resources with the same name to carry out the changes. Consequently updated_by_last_action? is not set. Subscribe to the inner powershell_script to chain resources.
 
 #### Actions
 - :create: creates or updates a certificate
@@ -100,7 +101,7 @@ Installs a certificate into the Windows certificate store from a file, and grant
 - :acl_add: adds read-only entries to a certificte's private key ACL
 
 #### Attribute Parameters
-- source: name attribute. The source file (for create and acl_add) or thumprint/subject (for delete and acl_add).
+- source: name attribute. The source file (for create and acl_add), thumprint (for delete and acl_add) or subject (for delete).
 - pfx_password: the password to access the source if it is a pfx file.
 - private_key_acl: array of 'domain\account' entries to be granted read-only access to the certificte's private key. This is not idempotent.
 - store_name: the certificate store to maniplate. One of MY (default : personal store), CA (trusted intermediate store) or ROOT (trusted root store)

--- a/README.md
+++ b/README.md
@@ -93,7 +93,6 @@ end
 ### windows_certificate
 
 Installs a certificate into the Windows certificate store from a file, and grants read-only access to the private key for designated accounts.
-Note that this resource generates powershell_script resources with the same name to carry out the changes. Consequently updated_by_last_action? is not set. Subscribe to the inner powershell_script to chain resources.
 
 #### Actions
 - :create: creates or updates a certificate

--- a/providers/certificate.rb
+++ b/providers/certificate.rb
@@ -1,0 +1,160 @@
+#
+# Author:: Richard Lavey (richard.lavey@calastone.com)
+# Cookbook Name:: windows
+# Provider:: certificate
+#
+# Copyright:: 2015, Calastone Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# See this for info on certutil
+# https://technet.microsoft.com/en-gb/library/cc732443.aspx
+
+include Chef::Mixin::ShellOut
+include Chef::Mixin::PowershellOut
+include Windows::Helper
+
+# Support whyrun
+def whyrun_supported?
+  true
+end
+
+action :create do
+	# we create from a file...
+	file = win_friendly_path(@new_resource.source)
+	
+	hash = getHashFromFile(file)
+	if isCertInStore?(hash)
+		Chef::Log.debug("#{@new_resource.source} already exists - nothing to do")
+	else
+		converge_by("Adding #{ @new_resource.source }") do
+			addCertToStore!(file)
+			updateAcl!(hash)
+		end
+	end
+
+end
+
+# acl_add is a modify-if-exists operation : not idempotent
+action :acl_add do
+	hash = nil
+
+	if ::File.exists?(@new_resource.source)
+		# source is a file so get hash from that
+		file = win_friendly_path(@new_resource.source)
+		hash = getHashFromFile(file)
+	else
+		# make sure we have no spaces in the hash string
+		hash = @new_resource.source.gsub(/\s/, '')
+	end
+	
+	if isCertInStore?(hash)
+		converge_by("Adding to ACL of #{hash}") do
+			updateAcl!(hash)
+		end
+	else
+		Chef::Log.debug("#{@new_resource.source} does not exist - nothing to do")
+	end
+end
+
+action :delete do
+	# on delete the source should id the cert (subject, hash, serial number etc.)
+	if isCertInStore?(@new_resource.source)
+		converge_by("Deleting #{ @current_resource.source }") do
+			user = " -user" if @new_resource.user_store
+			cmd = shell_out!("#{@command}#{user} -delstore #{@new_resource.store_name} \"#{@current_resource.source}\"")
+		end
+	else
+		Chef::Log.debug("#{@new_resource.source} does not exist - nothing to do")
+	end
+end
+
+def load_current_resource
+	@current_resource = Chef::Resource::WindowsCertificate.new(@new_resource.name)
+	@current_resource.source(@new_resource.source)
+	@current_resource.pfx_password(@new_resource.pfx_password)
+	@current_resource.private_key_acl(@new_resource.private_key_acl)
+	@current_resource.store_name(@new_resource.store_name)
+	@current_resource.user_store(@new_resource.user_store)
+
+	@command = locate_sysnative_cmd("certutil.exe")
+end
+
+private
+def getHashFromFile(file)
+	if file.downcase.end_with?('pfx') && (@new_resource.pfx_password.nil? || @new_resource.pfx_password.empty?)
+		raise "No password given for PFX file"
+	end
+	
+	password = " -p #{@new_resource.pfx_password}" if file.downcase.end_with?('pfx')
+	cmd = shell_out("#{@command}#{password} \"#{file}\"")
+	Chef::Log.debug "certutil reports: #{cmd.stdout}"
+	
+	# extract values from returned text
+	if cmd.exitstatus == 0
+		m = cmd.stdout.scan(/Cert Hash\(sha1\): (.+)/)
+		if m.length > 0
+			# remove spaces from the hash
+			m[m.length - 1][0].gsub(/\s/, '')
+		else
+			raise "Couldn't find hash in output : #{cmd.stdout}"
+		end
+	else
+		raise "certutil returned error #{cmd.exitstatus} : #{cmd.stderr} #{cmd.stdout}"
+	end
+end
+
+def isCertInStore?(certHash)
+	user = " -user" if @new_resource.user_store
+	cmd = shell_out("#{@command}#{user} -store #{@new_resource.store_name} \"#{certHash}\"")
+	Chef::Log.debug "certutil reports: #{cmd.stdout}"
+
+	cmd.exitstatus == 0
+end
+
+def addCertToStore!(file)
+	user = " -user" if @new_resource.user_store
+	if file.downcase.end_with?('pfx')
+		shell_out!("#{@command}#{user} -p #{@new_resource.pfx_password} -importpfx \"#{file}\"")
+	else
+		shell_out!("#{@command}#{user} -addstore #{@new_resource.store_name} \"#{file}\"")
+	end
+end
+
+def updateAcl!(certHash)
+	if (@new_resource.private_key_acl.nil? || @new_resource.private_key_acl.length == 0)
+		return
+	end
+	
+	raise "ACL can only be set on local machine certificates" if @new_resource.user_store
+	
+	# this PS came from http://blogs.technet.com/b/operationsguy/archive/2010/11/29/provide-access-to-private-keys-commandline-vs-powershell.aspx
+	ps_script = "& { $keyname=(((gci cert:\\LocalMachine\\#{@new_resource.store_name} | ? {$_.thumbprint -like '#{certHash}'}).PrivateKey).CspKeyContainerInfo).UniqueKeyContainerName; "
+	ps_script << "if ($keyname -eq $null) { throw 'no private key exists.'; } "
+	ps_script << "$fullpath = $env:ProgramData + '\\Microsoft\\Crypto\\RSA\\MachineKeys\\' + $keyname; "
+	@new_resource.private_key_acl.each do | name |
+		ps_script << "$uname = '#{name}'; "
+		ps_script << "icacls $fullpath /grant $uname`:RX; "
+	end
+	ps_script << "}"
+
+	Chef::Log.debug "Running PS script #{ps_script}"
+	p = powershell_out!(ps_script)
+	
+	if (!p.stderr.nil? && p.stderr.length > 0)
+		raise "#{ps_script} failed with #{p.stderr}"
+	end
+	
+	Chef::Log.debug "PS script returned: #{p.stdout}"
+end

--- a/providers/certificate.rb
+++ b/providers/certificate.rb
@@ -28,6 +28,8 @@ def whyrun_supported?
   true
 end
 
+use_inline_resources
+
 action :create do
   # We can do everything in a powershell script resource
   file = win_friendly_path(@new_resource.source)

--- a/providers/certificate.rb
+++ b/providers/certificate.rb
@@ -21,8 +21,6 @@
 # See this for info on certutil
 # https://technet.microsoft.com/en-gb/library/cc732443.aspx
 
-include Chef::Mixin::ShellOut
-include Chef::Mixin::PowershellOut
 include Windows::Helper
 
 # Support whyrun
@@ -31,52 +29,81 @@ def whyrun_supported?
 end
 
 action :create do
-  # we create from a file...
+  # We can do everything in a powershell script resource
   file = win_friendly_path(@new_resource.source)
-  
-  hash = getHashFromFile(file)
-  if isCertInStore?(hash)
-    Chef::Log.debug("#{@new_resource.source} already exists - nothing to do")
-  else
-    converge_by("Adding #{ @new_resource.source }") do
-      addCertToStore!(file)
-      updateAcl!(hash)
-    end
-  end
+  isPfx = file.downcase.end_with?('pfx')
+  password = ", \"#{@new_resource.pfx_password}\"" if isPfx
+  persistKeySet = ', ([System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::PersistKeySet)' if isPfx
 
+  codeScript = <<-EOH
+    $store = New-Object System.Security.Cryptography.X509Certificates.X509Store "#{@new_resource.store_name}", ([System.Security.Cryptography.X509Certificates.StoreLocation]::#{@location})
+    $cert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2 "#{file}"#{password}#{persistKeySet}
+    $store.Open([System.Security.Cryptography.X509Certificates.OpenFlags]::ReadWrite)
+    $store.Add($cert)
+    $store.Close()
+    #{getAclScript('$cert.GetCertHashString()')}
+  EOH
+  notifScript = <<-EOH
+    $cert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2 "#{file}"#{password}
+    Test-Path "cert:\\#{@location}\\#{@new_resource.store_name}\\$($cert.GetCertHashString())"
+  EOH
+  
+  powershell_script @new_resource.name do
+    code codeScript
+    not_if notifScript
+  end
 end
 
 # acl_add is a modify-if-exists operation : not idempotent
 action :acl_add do
+  # We can do everything in a powershell script resource
   hash = nil
 
   if ::File.exists?(@new_resource.source)
     # source is a file so get hash from that
     file = win_friendly_path(@new_resource.source)
-    hash = getHashFromFile(file)
+    password = ", \"#{@new_resource.pfx_password}\"" if file.downcase.end_with?('pfx')
+    hash = "(New-Object System.Security.Cryptography.X509Certificates.X509Certificate2 \"#{file}\"#{password}).GetCertHashString()"
   else
     # make sure we have no spaces in the hash string
-    hash = @new_resource.source.gsub(/\s/, '')
+    hash = "\"#{@new_resource.source.gsub(/\s/, '')}\""
   end
   
-  if isCertInStore?(hash)
-    converge_by("Adding to ACL of #{hash}") do
-      updateAcl!(hash)
-    end
-  else
-    Chef::Log.debug("#{@new_resource.source} does not exist - nothing to do")
+  codeScript = <<-EOH
+    #{getAclScript(hash)}
+  EOH
+  onlyifScript = <<-EOH
+    $hash = #{hash}
+    Test-Path "cert:\\#{@location}\\#{@new_resource.store_name}\\$hash"
+  EOH
+  
+  powershell_script @new_resource.name do
+    code codeScript
+    only_if onlyifScript
   end
 end
 
 action :delete do
-  # on delete the source should id the cert (subject, hash, serial number etc.)
-  if isCertInStore?(@new_resource.source)
-    converge_by("Deleting #{ @current_resource.source }") do
-      user = " -user" if @new_resource.user_store
-      cmd = shell_out!("#{@command}#{user} -delstore #{@new_resource.store_name} \"#{@current_resource.source}\"")
-    end
-  else
-    Chef::Log.debug("#{@new_resource.source} does not exist - nothing to do")
+  # We can do everything in a powershell script resource
+  subject = @current_resource.source.sub(/\*/, '`*') # escape any * in the source
+  certCommand = "gci cert:\\#{@location}\\#{@new_resource.store_name} | where { $_.Subject -like '*#{subject}*' -or $_.Thumbprint -eq '#{subject}'}"
+  
+  codeScript = <<-EOH
+    $store = New-Object System.Security.Cryptography.X509Certificates.X509Store "#{@new_resource.store_name}", ([System.Security.Cryptography.X509Certificates.StoreLocation]::#{@location})
+    $store.Open([System.Security.Cryptography.X509Certificates.OpenFlags]::ReadWrite)
+    foreach ($c in #{certCommand})
+    {
+      $store.Remove($c)
+    }
+    $store.Close()
+  EOH
+  onlyifScript = <<-EOH
+    (#{certCommand}).Count -gt 0
+  EOH
+  
+  powershell_script @new_resource.name do
+    code codeScript
+    only_if onlyifScript
   end
 end
 
@@ -87,74 +114,27 @@ def load_current_resource
   @current_resource.private_key_acl(@new_resource.private_key_acl)
   @current_resource.store_name(@new_resource.store_name)
   @current_resource.user_store(@new_resource.user_store)
-
-  @command = locate_sysnative_cmd("certutil.exe")
+  @location = @current_resource.user_store ? 'CurrrentUser' : 'LocalMachine'
 end
 
 private
-def getHashFromFile(file)
-  if file.downcase.end_with?('pfx') && (@new_resource.pfx_password.nil? || @new_resource.pfx_password.empty?)
-    raise "No password given for PFX file"
-  end
-  
-  password = " -p #{@new_resource.pfx_password}" if file.downcase.end_with?('pfx')
-  cmd = shell_out("#{@command}#{password} \"#{file}\"")
-  Chef::Log.debug "certutil reports: #{cmd.stdout}"
-  
-  # extract values from returned text
-  if cmd.exitstatus == 0
-    m = cmd.stdout.scan(/Cert Hash\(sha1\): (.+)/)
-    if m.length > 0
-      # remove spaces from the hash
-      m[m.length - 1][0].gsub(/\s/, '')
-    else
-      raise "Couldn't find hash in output : #{cmd.stdout}"
+def getAclScript(hash)
+  if (!@new_resource.private_key_acl.nil? && @new_resource.private_key_acl.length > 0)
+    raise "ACL can only be set on local machine certificates" if @new_resource.user_store
+
+    # this PS came from http://blogs.technet.com/b/operationsguy/archive/2010/11/29/provide-access-to-private-keys-commandline-vs-powershell.aspx
+    setAclScript = <<-EOH
+      $hash = #{hash}
+      $storeCert = gci "cert:\\#{@location}\\#{@new_resource.store_name}\\$hash"
+      if ($storeCert -eq $null) { throw 'no key exists.' } 
+      $keyname = $storeCert.PrivateKey.CspKeyContainerInfo.UniqueKeyContainerName
+      if ($keyname -eq $null) { throw 'no private key exists.' } 
+      $fullpath = "$env:ProgramData\\Microsoft\\Crypto\\RSA\\MachineKeys\\$keyname"
+    EOH
+    @new_resource.private_key_acl.each do | name |
+      setAclScript << "$uname='#{name}'; icacls $fullpath /grant $uname`:RX;"
     end
-  else
-    raise "certutil returned error #{cmd.exitstatus} : #{cmd.stderr} #{cmd.stdout}"
+    
+    setAclScript
   end
-end
-
-def isCertInStore?(certHash)
-  user = " -user" if @new_resource.user_store
-  cmd = shell_out("#{@command}#{user} -store #{@new_resource.store_name} \"#{certHash}\"")
-  Chef::Log.debug "certutil reports: #{cmd.stdout}"
-
-  cmd.exitstatus == 0
-end
-
-def addCertToStore!(file)
-  user = " -user" if @new_resource.user_store
-  if file.downcase.end_with?('pfx')
-    shell_out!("#{@command}#{user} -p #{@new_resource.pfx_password} -importpfx \"#{file}\"")
-  else
-    shell_out!("#{@command}#{user} -addstore #{@new_resource.store_name} \"#{file}\"")
-  end
-end
-
-def updateAcl!(certHash)
-  if (@new_resource.private_key_acl.nil? || @new_resource.private_key_acl.length == 0)
-    return
-  end
-  
-  raise "ACL can only be set on local machine certificates" if @new_resource.user_store
-  
-  # this PS came from http://blogs.technet.com/b/operationsguy/archive/2010/11/29/provide-access-to-private-keys-commandline-vs-powershell.aspx
-  ps_script = "& { $keyname=(((gci cert:\\LocalMachine\\#{@new_resource.store_name} | ? {$_.thumbprint -like '#{certHash}'}).PrivateKey).CspKeyContainerInfo).UniqueKeyContainerName; "
-  ps_script << "if ($keyname -eq $null) { throw 'no private key exists.'; } "
-  ps_script << "$fullpath = $env:ProgramData + '\\Microsoft\\Crypto\\RSA\\MachineKeys\\' + $keyname; "
-  @new_resource.private_key_acl.each do | name |
-    ps_script << "$uname = '#{name}'; "
-    ps_script << "icacls $fullpath /grant $uname`:RX; "
-  end
-  ps_script << "}"
-
-  Chef::Log.debug "Running PS script #{ps_script}"
-  p = powershell_out!(ps_script)
-  
-  if (!p.stderr.nil? && p.stderr.length > 0)
-    raise "#{ps_script} failed with #{p.stderr}"
-  end
-  
-  Chef::Log.debug "PS script returned: #{p.stdout}"
 end

--- a/providers/certificate.rb
+++ b/providers/certificate.rb
@@ -31,130 +31,130 @@ def whyrun_supported?
 end
 
 action :create do
-	# we create from a file...
-	file = win_friendly_path(@new_resource.source)
-	
-	hash = getHashFromFile(file)
-	if isCertInStore?(hash)
-		Chef::Log.debug("#{@new_resource.source} already exists - nothing to do")
-	else
-		converge_by("Adding #{ @new_resource.source }") do
-			addCertToStore!(file)
-			updateAcl!(hash)
-		end
-	end
+  # we create from a file...
+  file = win_friendly_path(@new_resource.source)
+  
+  hash = getHashFromFile(file)
+  if isCertInStore?(hash)
+    Chef::Log.debug("#{@new_resource.source} already exists - nothing to do")
+  else
+    converge_by("Adding #{ @new_resource.source }") do
+      addCertToStore!(file)
+      updateAcl!(hash)
+    end
+  end
 
 end
 
 # acl_add is a modify-if-exists operation : not idempotent
 action :acl_add do
-	hash = nil
+  hash = nil
 
-	if ::File.exists?(@new_resource.source)
-		# source is a file so get hash from that
-		file = win_friendly_path(@new_resource.source)
-		hash = getHashFromFile(file)
-	else
-		# make sure we have no spaces in the hash string
-		hash = @new_resource.source.gsub(/\s/, '')
-	end
-	
-	if isCertInStore?(hash)
-		converge_by("Adding to ACL of #{hash}") do
-			updateAcl!(hash)
-		end
-	else
-		Chef::Log.debug("#{@new_resource.source} does not exist - nothing to do")
-	end
+  if ::File.exists?(@new_resource.source)
+    # source is a file so get hash from that
+    file = win_friendly_path(@new_resource.source)
+    hash = getHashFromFile(file)
+  else
+    # make sure we have no spaces in the hash string
+    hash = @new_resource.source.gsub(/\s/, '')
+  end
+  
+  if isCertInStore?(hash)
+    converge_by("Adding to ACL of #{hash}") do
+      updateAcl!(hash)
+    end
+  else
+    Chef::Log.debug("#{@new_resource.source} does not exist - nothing to do")
+  end
 end
 
 action :delete do
-	# on delete the source should id the cert (subject, hash, serial number etc.)
-	if isCertInStore?(@new_resource.source)
-		converge_by("Deleting #{ @current_resource.source }") do
-			user = " -user" if @new_resource.user_store
-			cmd = shell_out!("#{@command}#{user} -delstore #{@new_resource.store_name} \"#{@current_resource.source}\"")
-		end
-	else
-		Chef::Log.debug("#{@new_resource.source} does not exist - nothing to do")
-	end
+  # on delete the source should id the cert (subject, hash, serial number etc.)
+  if isCertInStore?(@new_resource.source)
+    converge_by("Deleting #{ @current_resource.source }") do
+      user = " -user" if @new_resource.user_store
+      cmd = shell_out!("#{@command}#{user} -delstore #{@new_resource.store_name} \"#{@current_resource.source}\"")
+    end
+  else
+    Chef::Log.debug("#{@new_resource.source} does not exist - nothing to do")
+  end
 end
 
 def load_current_resource
-	@current_resource = Chef::Resource::WindowsCertificate.new(@new_resource.name)
-	@current_resource.source(@new_resource.source)
-	@current_resource.pfx_password(@new_resource.pfx_password)
-	@current_resource.private_key_acl(@new_resource.private_key_acl)
-	@current_resource.store_name(@new_resource.store_name)
-	@current_resource.user_store(@new_resource.user_store)
+  @current_resource = Chef::Resource::WindowsCertificate.new(@new_resource.name)
+  @current_resource.source(@new_resource.source)
+  @current_resource.pfx_password(@new_resource.pfx_password)
+  @current_resource.private_key_acl(@new_resource.private_key_acl)
+  @current_resource.store_name(@new_resource.store_name)
+  @current_resource.user_store(@new_resource.user_store)
 
-	@command = locate_sysnative_cmd("certutil.exe")
+  @command = locate_sysnative_cmd("certutil.exe")
 end
 
 private
 def getHashFromFile(file)
-	if file.downcase.end_with?('pfx') && (@new_resource.pfx_password.nil? || @new_resource.pfx_password.empty?)
-		raise "No password given for PFX file"
-	end
-	
-	password = " -p #{@new_resource.pfx_password}" if file.downcase.end_with?('pfx')
-	cmd = shell_out("#{@command}#{password} \"#{file}\"")
-	Chef::Log.debug "certutil reports: #{cmd.stdout}"
-	
-	# extract values from returned text
-	if cmd.exitstatus == 0
-		m = cmd.stdout.scan(/Cert Hash\(sha1\): (.+)/)
-		if m.length > 0
-			# remove spaces from the hash
-			m[m.length - 1][0].gsub(/\s/, '')
-		else
-			raise "Couldn't find hash in output : #{cmd.stdout}"
-		end
-	else
-		raise "certutil returned error #{cmd.exitstatus} : #{cmd.stderr} #{cmd.stdout}"
-	end
+  if file.downcase.end_with?('pfx') && (@new_resource.pfx_password.nil? || @new_resource.pfx_password.empty?)
+    raise "No password given for PFX file"
+  end
+  
+  password = " -p #{@new_resource.pfx_password}" if file.downcase.end_with?('pfx')
+  cmd = shell_out("#{@command}#{password} \"#{file}\"")
+  Chef::Log.debug "certutil reports: #{cmd.stdout}"
+  
+  # extract values from returned text
+  if cmd.exitstatus == 0
+    m = cmd.stdout.scan(/Cert Hash\(sha1\): (.+)/)
+    if m.length > 0
+      # remove spaces from the hash
+      m[m.length - 1][0].gsub(/\s/, '')
+    else
+      raise "Couldn't find hash in output : #{cmd.stdout}"
+    end
+  else
+    raise "certutil returned error #{cmd.exitstatus} : #{cmd.stderr} #{cmd.stdout}"
+  end
 end
 
 def isCertInStore?(certHash)
-	user = " -user" if @new_resource.user_store
-	cmd = shell_out("#{@command}#{user} -store #{@new_resource.store_name} \"#{certHash}\"")
-	Chef::Log.debug "certutil reports: #{cmd.stdout}"
+  user = " -user" if @new_resource.user_store
+  cmd = shell_out("#{@command}#{user} -store #{@new_resource.store_name} \"#{certHash}\"")
+  Chef::Log.debug "certutil reports: #{cmd.stdout}"
 
-	cmd.exitstatus == 0
+  cmd.exitstatus == 0
 end
 
 def addCertToStore!(file)
-	user = " -user" if @new_resource.user_store
-	if file.downcase.end_with?('pfx')
-		shell_out!("#{@command}#{user} -p #{@new_resource.pfx_password} -importpfx \"#{file}\"")
-	else
-		shell_out!("#{@command}#{user} -addstore #{@new_resource.store_name} \"#{file}\"")
-	end
+  user = " -user" if @new_resource.user_store
+  if file.downcase.end_with?('pfx')
+    shell_out!("#{@command}#{user} -p #{@new_resource.pfx_password} -importpfx \"#{file}\"")
+  else
+    shell_out!("#{@command}#{user} -addstore #{@new_resource.store_name} \"#{file}\"")
+  end
 end
 
 def updateAcl!(certHash)
-	if (@new_resource.private_key_acl.nil? || @new_resource.private_key_acl.length == 0)
-		return
-	end
-	
-	raise "ACL can only be set on local machine certificates" if @new_resource.user_store
-	
-	# this PS came from http://blogs.technet.com/b/operationsguy/archive/2010/11/29/provide-access-to-private-keys-commandline-vs-powershell.aspx
-	ps_script = "& { $keyname=(((gci cert:\\LocalMachine\\#{@new_resource.store_name} | ? {$_.thumbprint -like '#{certHash}'}).PrivateKey).CspKeyContainerInfo).UniqueKeyContainerName; "
-	ps_script << "if ($keyname -eq $null) { throw 'no private key exists.'; } "
-	ps_script << "$fullpath = $env:ProgramData + '\\Microsoft\\Crypto\\RSA\\MachineKeys\\' + $keyname; "
-	@new_resource.private_key_acl.each do | name |
-		ps_script << "$uname = '#{name}'; "
-		ps_script << "icacls $fullpath /grant $uname`:RX; "
-	end
-	ps_script << "}"
+  if (@new_resource.private_key_acl.nil? || @new_resource.private_key_acl.length == 0)
+    return
+  end
+  
+  raise "ACL can only be set on local machine certificates" if @new_resource.user_store
+  
+  # this PS came from http://blogs.technet.com/b/operationsguy/archive/2010/11/29/provide-access-to-private-keys-commandline-vs-powershell.aspx
+  ps_script = "& { $keyname=(((gci cert:\\LocalMachine\\#{@new_resource.store_name} | ? {$_.thumbprint -like '#{certHash}'}).PrivateKey).CspKeyContainerInfo).UniqueKeyContainerName; "
+  ps_script << "if ($keyname -eq $null) { throw 'no private key exists.'; } "
+  ps_script << "$fullpath = $env:ProgramData + '\\Microsoft\\Crypto\\RSA\\MachineKeys\\' + $keyname; "
+  @new_resource.private_key_acl.each do | name |
+    ps_script << "$uname = '#{name}'; "
+    ps_script << "icacls $fullpath /grant $uname`:RX; "
+  end
+  ps_script << "}"
 
-	Chef::Log.debug "Running PS script #{ps_script}"
-	p = powershell_out!(ps_script)
-	
-	if (!p.stderr.nil? && p.stderr.length > 0)
-		raise "#{ps_script} failed with #{p.stderr}"
-	end
-	
-	Chef::Log.debug "PS script returned: #{p.stdout}"
+  Chef::Log.debug "Running PS script #{ps_script}"
+  p = powershell_out!(ps_script)
+  
+  if (!p.stderr.nil? && p.stderr.length > 0)
+    raise "#{ps_script} failed with #{p.stderr}"
+  end
+  
+  Chef::Log.debug "PS script returned: #{p.stdout}"
 end

--- a/providers/certificate_binding.rb
+++ b/providers/certificate_binding.rb
@@ -77,7 +77,7 @@ def getCurrentHash()
   Chef::Log.debug "netsh reports: #{cmd.stdout}"
 
   if cmd.exitstatus == 0
-    m = cmd.stdout.scan(/Certificate Hash\s+:\s?(\w{40})/)
+    m = cmd.stdout.scan(/Certificate Hash\s+:\s?([A-Fa-f0-9]{40})/)
     if m.length == 0
       raise "Failed to extract hash from command output #{cmd.stdout}"
     else

--- a/providers/certificate_binding.rb
+++ b/providers/certificate_binding.rb
@@ -1,0 +1,121 @@
+#
+# Author:: Richard Lavey (richard.lavey@calastone.com)
+# Cookbook Name:: windows
+# Provider:: certificate_binding
+#
+# Copyright:: 2015, Calastone Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# See https://msdn.microsoft.com/en-us/library/windows/desktop/cc307236%28v=vs.85%29.aspx for netsh info
+
+include Chef::Mixin::ShellOut
+include Chef::Mixin::PowershellOut
+include Windows::Helper
+
+# Support whyrun
+def whyrun_supported?
+  true
+end
+
+action :create do
+	hash = @new_resource.name_kind == :subject ? getHashFromSubject() : @new_resource.cert_name
+
+	if @current_resource.exists
+		needsChange = (hash.casecmp(@current_hash) != 0)
+
+		if needsChange
+			converge_by("Changing #{@current_resource.address}:#{@current_resource.port}") do
+				deleteBinding
+				setBinding hash
+			end
+		else
+			Chef::Log.debug("#{@current_resource.address}:#{@current_resource.port} already bound to #{hash} - nothing to do")
+		end
+	else
+		converge_by("Binding #{@current_resource.address}:#{@current_resource.port}") do
+			setBinding hash
+		end
+	end
+end
+
+action :delete do
+	if @current_resource.exists 
+		converge_by("Deleting #{@current_resource.address}:#{@current_resource.port}") do
+			deleteBinding
+		end
+	else
+		Chef::Log.debug("#{@current_resource.address}:#{@current_resource.port} not bound - nothing to do")
+	end
+end
+
+def load_current_resource
+	@current_resource = Chef::Resource::WindowsCertificateBinding.new(@new_resource.name)
+	@current_resource.cert_name(@new_resource.cert_name)
+	@current_resource.name_kind(@new_resource.name_kind)
+	@current_resource.address(@new_resource.address)
+	@current_resource.port(@new_resource.port)
+
+	@command = locate_sysnative_cmd("netsh.exe")
+	getCurrentHash
+end
+
+private
+def getCurrentHash()
+	cmd = shell_out("#{@command} http show sslcert ipport=#{@current_resource.address}:#{@current_resource.port}")
+	Chef::Log.debug "netsh reports: #{cmd.stdout}"
+
+	if cmd.exitstatus == 0
+		m = cmd.stdout.scan(/Certificate Hash\s+:\s?(\w{40})/)
+		if m.length == 0
+			raise "Failed to extract hash from command output #{cmd.stdout}"
+		else
+			@current_hash = m[0][0]
+			@current_resource.exists = true
+		end		
+	else
+		@current_resource.exists = false
+	end
+end
+
+def setBinding(hash)
+	cmd = "#{@command} http add sslcert"
+	cmd << " ipport=#{@current_resource.address}:#{@current_resource.port}" 
+	cmd << " certhash=#{hash}"
+	cmd << " appid=#{@current_resource.app_id}"
+	cmd << " certstorename=#{@current_resource.store_name}"
+	
+	shell_out!(cmd)
+end
+
+def deleteBinding()
+	shell_out!("#{@command} http delete sslcert ipport=#{@current_resource.address}:#{@current_resource.port}")
+end
+
+def getHashFromSubject()
+	# escape wildcard subject name (*.acme.com)
+	subject = @current_resource.cert_name.sub(/\*/, '`*')
+	ps_script = "& { gci cert:\\localmachine\\#{@current_resource.store_name} | where subject -like '*#{subject}*' | select -first 1 -expandproperty Thumbprint }"
+
+	Chef::Log.debug "Running PS script #{ps_script}"
+	p = powershell_out!(ps_script)
+	
+	if (!p.stderr.nil? && p.stderr.length > 0)
+		raise "#{ps_script} failed with #{p.stderr}"
+	elsif (p.stdout.nil? || p.stdout.length == 0)
+		raise "Couldn't find thumbprint for subject #{@current_resource.cert_name}"
+	end
+
+	p.stdout.strip
+end

--- a/providers/certificate_binding.rb
+++ b/providers/certificate_binding.rb
@@ -30,92 +30,92 @@ def whyrun_supported?
 end
 
 action :create do
-	hash = @new_resource.name_kind == :subject ? getHashFromSubject() : @new_resource.cert_name
+  hash = @new_resource.name_kind == :subject ? getHashFromSubject() : @new_resource.cert_name
 
-	if @current_resource.exists
-		needsChange = (hash.casecmp(@current_hash) != 0)
+  if @current_resource.exists
+    needsChange = (hash.casecmp(@current_hash) != 0)
 
-		if needsChange
-			converge_by("Changing #{@current_resource.address}:#{@current_resource.port}") do
-				deleteBinding
-				setBinding hash
-			end
-		else
-			Chef::Log.debug("#{@current_resource.address}:#{@current_resource.port} already bound to #{hash} - nothing to do")
-		end
-	else
-		converge_by("Binding #{@current_resource.address}:#{@current_resource.port}") do
-			setBinding hash
-		end
-	end
+    if needsChange
+      converge_by("Changing #{@current_resource.address}:#{@current_resource.port}") do
+        deleteBinding
+        setBinding hash
+      end
+    else
+      Chef::Log.debug("#{@current_resource.address}:#{@current_resource.port} already bound to #{hash} - nothing to do")
+    end
+  else
+    converge_by("Binding #{@current_resource.address}:#{@current_resource.port}") do
+      setBinding hash
+    end
+  end
 end
 
 action :delete do
-	if @current_resource.exists 
-		converge_by("Deleting #{@current_resource.address}:#{@current_resource.port}") do
-			deleteBinding
-		end
-	else
-		Chef::Log.debug("#{@current_resource.address}:#{@current_resource.port} not bound - nothing to do")
-	end
+  if @current_resource.exists 
+    converge_by("Deleting #{@current_resource.address}:#{@current_resource.port}") do
+      deleteBinding
+    end
+  else
+    Chef::Log.debug("#{@current_resource.address}:#{@current_resource.port} not bound - nothing to do")
+  end
 end
 
 def load_current_resource
-	@current_resource = Chef::Resource::WindowsCertificateBinding.new(@new_resource.name)
-	@current_resource.cert_name(@new_resource.cert_name)
-	@current_resource.name_kind(@new_resource.name_kind)
-	@current_resource.address(@new_resource.address)
-	@current_resource.port(@new_resource.port)
+  @current_resource = Chef::Resource::WindowsCertificateBinding.new(@new_resource.name)
+  @current_resource.cert_name(@new_resource.cert_name)
+  @current_resource.name_kind(@new_resource.name_kind)
+  @current_resource.address(@new_resource.address)
+  @current_resource.port(@new_resource.port)
 
-	@command = locate_sysnative_cmd("netsh.exe")
-	getCurrentHash
+  @command = locate_sysnative_cmd("netsh.exe")
+  getCurrentHash
 end
 
 private
 def getCurrentHash()
-	cmd = shell_out("#{@command} http show sslcert ipport=#{@current_resource.address}:#{@current_resource.port}")
-	Chef::Log.debug "netsh reports: #{cmd.stdout}"
+  cmd = shell_out("#{@command} http show sslcert ipport=#{@current_resource.address}:#{@current_resource.port}")
+  Chef::Log.debug "netsh reports: #{cmd.stdout}"
 
-	if cmd.exitstatus == 0
-		m = cmd.stdout.scan(/Certificate Hash\s+:\s?(\w{40})/)
-		if m.length == 0
-			raise "Failed to extract hash from command output #{cmd.stdout}"
-		else
-			@current_hash = m[0][0]
-			@current_resource.exists = true
-		end		
-	else
-		@current_resource.exists = false
-	end
+  if cmd.exitstatus == 0
+    m = cmd.stdout.scan(/Certificate Hash\s+:\s?(\w{40})/)
+    if m.length == 0
+      raise "Failed to extract hash from command output #{cmd.stdout}"
+    else
+      @current_hash = m[0][0]
+      @current_resource.exists = true
+    end    
+  else
+    @current_resource.exists = false
+  end
 end
 
 def setBinding(hash)
-	cmd = "#{@command} http add sslcert"
-	cmd << " ipport=#{@current_resource.address}:#{@current_resource.port}" 
-	cmd << " certhash=#{hash}"
-	cmd << " appid=#{@current_resource.app_id}"
-	cmd << " certstorename=#{@current_resource.store_name}"
-	
-	shell_out!(cmd)
+  cmd = "#{@command} http add sslcert"
+  cmd << " ipport=#{@current_resource.address}:#{@current_resource.port}" 
+  cmd << " certhash=#{hash}"
+  cmd << " appid=#{@current_resource.app_id}"
+  cmd << " certstorename=#{@current_resource.store_name}"
+  
+  shell_out!(cmd)
 end
 
 def deleteBinding()
-	shell_out!("#{@command} http delete sslcert ipport=#{@current_resource.address}:#{@current_resource.port}")
+  shell_out!("#{@command} http delete sslcert ipport=#{@current_resource.address}:#{@current_resource.port}")
 end
 
 def getHashFromSubject()
-	# escape wildcard subject name (*.acme.com)
-	subject = @current_resource.cert_name.sub(/\*/, '`*')
-	ps_script = "& { gci cert:\\localmachine\\#{@current_resource.store_name} | where subject -like '*#{subject}*' | select -first 1 -expandproperty Thumbprint }"
+  # escape wildcard subject name (*.acme.com)
+  subject = @current_resource.cert_name.sub(/\*/, '`*')
+  ps_script = "& { gci cert:\\localmachine\\#{@current_resource.store_name} | where subject -like '*#{subject}*' | select -first 1 -expandproperty Thumbprint }"
 
-	Chef::Log.debug "Running PS script #{ps_script}"
-	p = powershell_out!(ps_script)
-	
-	if (!p.stderr.nil? && p.stderr.length > 0)
-		raise "#{ps_script} failed with #{p.stderr}"
-	elsif (p.stdout.nil? || p.stdout.length == 0)
-		raise "Couldn't find thumbprint for subject #{@current_resource.cert_name}"
-	end
+  Chef::Log.debug "Running PS script #{ps_script}"
+  p = powershell_out!(ps_script)
+  
+  if (!p.stderr.nil? && p.stderr.length > 0)
+    raise "#{ps_script} failed with #{p.stderr}"
+  elsif (p.stdout.nil? || p.stdout.length == 0)
+    raise "Couldn't find thumbprint for subject #{@current_resource.cert_name}"
+  end
 
-	p.stdout.strip
+  p.stdout.strip
 end

--- a/resources/certificate.rb
+++ b/resources/certificate.rb
@@ -1,0 +1,30 @@
+#
+# Author:: Richard Lavey (richard.lavey@calastone.com)
+# Cookbook Name:: windows
+# Resource:: certificate
+#
+# Copyright:: 2015, Calastone Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+actions :create, :delete, :acl_add
+default_action :create
+
+attribute :source, :kind_of => String, :name_attribute => true, :required => true
+attribute :pfx_password, :kind_of => String
+attribute :private_key_acl, :kind_of => Array
+attribute :store_name, :kind_of => String, :default => 'MY', :regex => /^(?:MY|CA|ROOT)$/
+attribute :user_store, :kind_of => [TrueClass, FalseClass], :default => false
+
+attr_accessor :exists

--- a/resources/certificate_binding.rb
+++ b/resources/certificate_binding.rb
@@ -1,0 +1,31 @@
+#
+# Author:: Richard Lavey (richard.lavey@calastone.com)
+# Cookbook Name:: windows
+# Resource:: certificate_binding
+#
+# Copyright:: 2015, Calastone Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+actions :create, :delete
+default_action :create
+
+attribute :cert_name, :kind_of => String, :name_attribute => true, :required => true
+attribute :name_kind, :kind_of => Symbol, :equal_to => [:hash, :subject], :default => :subject
+attribute :address, :kind_of => String, :default => '0.0.0.0'
+attribute :port, :kind_of => Integer, :default => 443
+attribute :app_id, :kind_of => String, :default => '{4dc3e181-e14b-4a21-b022-59fc669b0914}'
+attribute :store_name, :kind_of => String, :default => 'MY', :regex => /^(?:MY|CA|ROOT)$/
+
+attr_accessor :exists


### PR DESCRIPTION
Implements #211 

Allows
- Cert to be imported from cer, p7b and pfx files
- Add cert to personal, intermediate and root stores
- Add cert to machine or user stores
- Grant access to private key
- Bind a certificate to a port to enable TLS
