### PR TITLE
Fix #188 - we no longer need box urls.

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -15,19 +15,16 @@ platforms:
   - name: windows-8.1-chef11.10.4
     driver_config:
       box: windows-8.1
-      box_url: http://cdn.box-cutter.com/windows/virtualbox4.3.20/eval-win81x64-enterprise-nocm-1.0.2.box
     provisioner:
       require_chef_omnibus: 11.10.4
   - name: windows-8.1-chef11.16.4
     driver_config:
       box: windows-8.1
-      box_url: http://cdn.box-cutter.com/windows/virtualbox4.3.20/eval-win81x64-enterprise-nocm-1.0.2.box
     provisioner:
       require_chef_omnibus: 11.16.4
   - name: windows-8.1-chef12
     driver_config:
       box: windows-8.1
-      box_url: http://cdn.box-cutter.com/windows/virtualbox4.3.20/eval-win81x64-enterprise-nocm-1.0.2.box
     provisioner:
       require_chef_omnibus: 12
 


### PR DESCRIPTION
Test-Kitchen blog has instructions on how to roll your own boxes.