### PR TITLE
Certificate delete doesn't run on PS 2

### DIFF
--- a/providers/certificate.rb
+++ b/providers/certificate.rb
@@ -105,7 +105,7 @@ action :delete do
     $store.Close()
   EOH
   onlyifScript = <<-EOH
-    (#{certCommand}).Count -gt 0
+    @(#{certCommand}).Count -gt 0
   EOH
   
   # We can do everything in a powershell script resource


### PR DESCRIPTION
Powershell 2 doesn't treat a single item as an array meaning count returns null. Need to coerce to an array.