### PR TITLE
Fix certificate provider failing when being used remotely

### DIFF
--- a/providers/certificate.rb
+++ b/providers/certificate.rb
@@ -35,7 +35,7 @@ action :create do
   file = win_friendly_path(@new_resource.source)
   isPfx = file.downcase.end_with?('pfx')
   password = ", \"#{@new_resource.pfx_password}\"" if isPfx
-  persistKeySet = ', ([System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::PersistKeySet)' if isPfx
+  persistKeySet = ', ([System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::PersistKeySet -bor [System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::MachineKeyset)' if isPfx
 
   codeScript = <<-EOH
     $store = New-Object System.Security.Cryptography.X509Certificates.X509Store "#{@new_resource.store_name}", ([System.Security.Cryptography.X509Certificates.StoreLocation]::#{@location})

--- a/providers/certificate.rb
+++ b/providers/certificate.rb
@@ -122,7 +122,7 @@ def load_current_resource
   @current_resource.private_key_acl(@new_resource.private_key_acl)
   @current_resource.store_name(@new_resource.store_name)
   @current_resource.user_store(@new_resource.user_store)
-  @location = @current_resource.user_store ? 'CurrrentUser' : 'LocalMachine'
+  @location = @current_resource.user_store ? 'CurrentUser' : 'LocalMachine'
 end
 
 private


### PR DESCRIPTION
Using the certificate resource remotely, like winrm, would fail
while the exact same code would run properly locally.
Fixes #227 