### PR TITLE
Fix reboot detection of windows reboot handler and use Chef DSL when possible

### DIFF
--- a/files/default/handlers/windows_reboot_handler.rb
+++ b/files/default/handlers/windows_reboot_handler.rb
@@ -51,21 +51,25 @@ class WindowsRebootHandler < Chef::Handler
     node.run_state[:reboot_requested] == true
   end
 
-  # reboot cause WIN says so:
-  # reboot pending because of some configuration action we performed
-  def reboot_pending?
-    # this key will only exit if the system need a reboot to update some file currently in use
-    # see http://technet.microsoft.com/en-us/library/cc960241.aspx
-    Registry.value_exists?('HKLM\SYSTEM\CurrentControlSet\Control\Session Manager', 'PendingFileRenameOperations') ||
-    # 1 for any value means reboot pending
-    # "9306cdfc-c4a1-4a22-9996-848cb67eddc3"=1
-    (Registry.key_exists?('HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\RebootRequired') &&
-      Registry.get_values('HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\RebootRequired').select{|v| v[2] == 1 }.any?) ||
-    # this key will only exit if the system is pending a reboot
-    Registry.key_exists?('HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootPending') ||
-    # 1, 2 or 3 for 'Flags' value means reboot pending
-    (Registry.key_exists?('HKLM\SOFTWARE\Microsoft\Updates\UpdateExeVolatile') &&
-      [1, 2, 3].include?(Registry.get_value('HKLM\SOFTWARE\Microsoft\Updates\UpdateExeVolatile', 'Flags')))
+  if Chef::VERSION > '11.12'
+    include Chef::DSL::RebootPending
+  else
+    # reboot cause WIN says so:
+    # reboot pending because of some configuration action we performed
+    def reboot_pending?
+      # this key will only exit if the system need a reboot to update some file currently in use
+      # see http://technet.microsoft.com/en-us/library/cc960241.aspx
+      Registry.value_exists?('HKLM\SYSTEM\CurrentControlSet\Control\Session Manager', 'PendingFileRenameOperations') ||
+      # 1 for any value means reboot pending
+      # "9306cdfc-c4a1-4a22-9996-848cb67eddc3"=1
+      (Registry.key_exists?('HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\RebootRequired') &&
+        Registry.get_values('HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\RebootRequired').select{|v| v[2] == 1 }.any?) ||
+      # this key will only exit if the system is pending a reboot
+      ::Registry.key_exists?('HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootPending') ||
+      # 1, 2 or 3 for 'Flags' value means reboot pending
+      (Registry.key_exists?('HKLM\SOFTWARE\Microsoft\Updates\UpdateExeVolatile') &&
+        [1, 2, 3].include?(Registry.get_value('HKLM\SOFTWARE\Microsoft\Updates\UpdateExeVolatile', 'Flags')))
+    end
   end
 
   def timeout

--- a/files/default/handlers/windows_reboot_handler.rb
+++ b/files/default/handlers/windows_reboot_handler.rb
@@ -54,9 +54,9 @@ class WindowsRebootHandler < Chef::Handler
   # reboot cause WIN says so:
   # reboot pending because of some configuration action we performed
   def reboot_pending?
-    # Any files listed here means reboot needed
-    (Registry.key_exists?('HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\PendingFileRenameOperations') &&
-      Registry.get_value('HKLM\SYSTEM\CurrentControlSet\Control\Session Manager','PendingFileRenameOperations').any?) ||
+    # this key will only exit if the system need a reboot to update some file currently in use
+    # see http://technet.microsoft.com/en-us/library/cc960241.aspx
+    Registry.value_exists?('HKLM\SYSTEM\CurrentControlSet\Control\Session Manager', 'PendingFileRenameOperations') ||
     # 1 for any value means reboot pending
     # "9306cdfc-c4a1-4a22-9996-848cb67eddc3"=1
     (Registry.key_exists?('HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\RebootRequired') &&

--- a/files/default/handlers/windows_reboot_handler.rb
+++ b/files/default/handlers/windows_reboot_handler.rb
@@ -63,9 +63,9 @@ class WindowsRebootHandler < Chef::Handler
       Registry.get_values('HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\RebootRequired').select{|v| v[2] == 1 }.any?) ||
     # this key will only exit if the system is pending a reboot
     Registry.key_exists?('HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootPending') ||
-    # 1 or 2 for 'Flags' value means reboot pending
+    # 1, 2 or 3 for 'Flags' value means reboot pending
     (Registry.key_exists?('HKLM\SOFTWARE\Microsoft\Updates\UpdateExeVolatile') &&
-      [1,2].include?(Registry::get_value('HKLM\SOFTWARE\Microsoft\Updates\UpdateExeVolatile','Flags')))
+      [1, 2, 3].include?(Registry.get_value('HKLM\SOFTWARE\Microsoft\Updates\UpdateExeVolatile', 'Flags')))
   end
 
   def timeout

--- a/files/default/handlers/windows_reboot_handler.rb
+++ b/files/default/handlers/windows_reboot_handler.rb
@@ -61,6 +61,8 @@ class WindowsRebootHandler < Chef::Handler
     # "9306cdfc-c4a1-4a22-9996-848cb67eddc3"=1
     (Registry.key_exists?('HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\RebootRequired') &&
       Registry.get_values('HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\RebootRequired').select{|v| v[2] == 1 }.any?) ||
+    # this key will only exit if the system is pending a reboot
+    Registry.key_exists?('HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootPending') ||
     # 1 or 2 for 'Flags' value means reboot pending
     (Registry.key_exists?('HKLM\SOFTWARE\Microsoft\Updates\UpdateExeVolatile') &&
       [1,2].include?(Registry::get_value('HKLM\SOFTWARE\Microsoft\Updates\UpdateExeVolatile','Flags')))


### PR DESCRIPTION
Current implementation of the Windows reboot Handler `reboot_pending?` method is a bit buggy:
* `HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\PendingFileRenameOperations` is not a key but a value
* `HKLM\SOFTWARE\Microsoft\Updates\UpdateExeVolatile` with a value of 3 also means a reboot is needed
* The CBS key is not handled at all

This commit fix these bugs, but most of all use the Chef DSL method (which is correct) if possible