### PR TITLE
Suppress warning in chefspec with chef 12.4

### DIFF
--- a/libraries/windows_package.rb
+++ b/libraries/windows_package.rb
@@ -194,7 +194,7 @@ class Chef
   class Resource
     class WindowsCookbookPackage < Chef::Resource::LWRPBase
       if Gem::Version.new(Chef::VERSION) >= Gem::Version.new('12')
-        provides :windows_package, os: "windows"
+        provides :windows_package, os: "windows", override: true
       end
       actions :install, :remove
 


### PR DESCRIPTION
This PR will suppress following warning when running chefspec with chef 12.4:

```
WARN: You are overriding windows_package on {:os=>"windows"} with Chef::Resource::WindowsCookbookPackage: used to be Chef::Resource::Wi
ndowsPackage. Use override: true if this is what you intended.
```

For information, from Chef12.4, it gives warning when you are replacing DSL provided by another resource or provider class:

```ruby
class X < Chef::Resource
  provides :file
end
class Y < Chef::Resource
  provides :file
end
```

This will emit a warning that Y is overriding X. To disable the warning, use override: true:

```ruby
class X < Chef::Resource
  provides :file
end
class Y < Chef::Resource
  provides :file, override: true
end
```

reference:
https://www.chef.io/blog/2015/06/24/chef-client-12-4-0-released/
