### PR TITLE
Allow spaces in windows package sources

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -46,3 +46,7 @@ suites:
     run_list:
       - recipe[windows::default]
       - recipe[minimal::certificate]
+  - name: package
+    run_list:
+      - recipe[windows::default]
+      - recipe[minimal::package]

--- a/test/cookbooks/minimal/recipes/package.rb
+++ b/test/cookbooks/minimal/recipes/package.rb
@@ -1,0 +1,10 @@
+remote_file 'C:\\Firefox Setup 5.0.exe' do
+  source 'http://archive.mozilla.org/pub/mozilla.org/mozilla.org/firefox/releases/5.0/win32/en-US/Firefox%20Setup%205.0.exe'
+end
+
+windows_package 'Mozilla Firefox 5.0 (x86 en-US)' do
+  source 'file:///C:/Firefox Setup 5.0.exe'
+  options '-ms'
+  installer_type :custom
+  action :install
+end

--- a/test/integration/package/pester/minimal.package.Tests.ps1
+++ b/test/integration/package/pester/minimal.package.Tests.ps1
@@ -1,0 +1,11 @@
+$global:progressPreference = 'SilentlyContinue'
+
+describe 'minimal::package' {
+  context 'minimal_package' {
+
+    it "task 'task_for_system' was created"  {
+      Test-Path "C:\Program Files (x86)\Mozilla Firefox\firefox.exe" | Should Be True
+    }
+  }
+}
+


### PR DESCRIPTION
Previously, a URI with spaces would fail when passed as `source` to a `windows_package` resource.
For example:
```ruby
windows_package 'Mozilla Firefox 5.0 (x86 en-US)' do
  source 'http://archive.mozilla.org/pub/mozilla.org/mozilla.org/firefox/releases/5.0/win32/en-US/Firefox Setup 5.0.exe'
  options '-ms'
  installer_type :custom
  action :install
end
```

cc @adamedx @smurawski @ksubrama 