### PR TITLE
Adds powershell provider example

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,16 @@ Disable Telnet client/server
 end
 ```
 
+Add SMTP Feature with powershell provider 
+
+```ruby
+windows_feature "smtp-server" do
+  action :install
+  all true
+  provider :windows_feature_powershell
+end
+```
+
 ### windows_font
 Installs a font.
 


### PR DESCRIPTION
There are no powershell provider examples. Adds one that has been tested and works on win 2012r2. 
There is no dism package available for smtp